### PR TITLE
Automatic_updating

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class="message__upper">
             <div class="message__upper--name">
               ${message.user_name}
@@ -21,7 +21,7 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="message">
+       `<div class="message" data-message-id=${message.id}>
           <div class=""message__upper">
             <div class="message__upper--name">
               ${message.user_name}
@@ -62,4 +62,29 @@ $(function(){
       alert('メッセージ送信に失敗しました');
     })
   })
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: "GET",
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0){
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight})
+      }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);  
+  }
 });

--- a/app/assets/stylesheets/_side_block.scss
+++ b/app/assets/stylesheets/_side_block.scss
@@ -47,30 +47,33 @@
   .rooms {
     height: calc(100vh - 100px);
     background-color: $side_blue_light;
+    overflow: scroll;
     
       .room {
         height: 100px;
         padding-top: 20px;
-        
-        &__name {
-          height: 20px;
-          width: 260px;
-          margin: auto;
-          font-size: 16px;
-          line-height: 20px;
-          color: $white;
-         
-        }
 
-        &__message {
-          height: 15px;
-          width: 260px;
-          margin: 5px auto;
-          font-size: 11px;
-          line-height: 15px;
-          color: $white;
-        }
+        .room-btn {
+          text-decoration: none;
 
+          &__name {
+            height: 20px;
+            width: 260px;
+            margin: auto;
+            font-size: 16px;
+            line-height: 20px;
+            color: $white;
+          }
+
+          &__message {
+            height: 15px;
+            width: 260px;
+            margin: 5px auto;
+            font-size: 11px;
+            line-height: 15px;
+            color: $white;
+          }
+        }
       }
   }
 }

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper
     .message__upper--name
       = message.user.name

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -11,8 +11,8 @@
   .rooms
     - current_user.groups.each do |group|
       .room
-        = link_to group_messages_path(group) do
-          .room__name
+        = link_to group_messages_path(group), class: "room-btn" do
+          .room-btn__name
             = group.name
-          .room__message
+          .room-btn__message
             = group.show_last_message

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name  @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日  %h時%M分")
 json.content @message.content
 json.image  @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
・カリキュラムに基づいて自動更新を実装しました。
・一部のビューの乱れも修正しました。（side-bar内のグループ名と最新投稿の文字にあったアンダーラインの削除、同じくside-bar内に表示する
<img width="1255" alt="スクリーンショット 2020-04-25 1 26 36" src="https://user-images.githubusercontent.com/63444344/80234870-d334f880-8693-11ea-8d8e-71d15baea70b.png">
グループ数が多くなってもはみ出して表示しないように修正）

#Why
自動更新の実装によりユーザが自らブラウザの更新を行う手間を無くし、よりリアルタイムに近い形でのメッセージのやりとりができるようになる。